### PR TITLE
/fix: Update README.md because direct link for contributors was leadi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <small>
     Feito com 💙 pela 
       <a href="https://github.com/FieldControl">FieldControl</a> e
-      <a href="https://github.com/FieldControl/contaazul/graphs/contributors">contribuidores</a> - <a href="https://fieldcontrol.com.br/vaga-para-desenvolvedor.html?utm_source=github&utm_medium=opensource&utm_campaign=carchost-node">Estamos contratando!</a>
+      <a href="https://github.com/FieldControl/carchost-node/graphs/contributors">contribuidores</a> - <a href="https://fieldcontrol.com.br/vaga-para-desenvolvedor.html?utm_source=github&utm_medium=opensource&utm_campaign=carchost-node">Estamos contratando!</a>
   </small>
 </div>
 


### PR DESCRIPTION
I was looking at some of your repositories and I noticed that there was a redirect error in the readme link, anyway, if you have anything there, for me to help and contribute, than is open, I took a look and it seems that most of them need a key of api to at least try to do something..... so if you can guide me on how to get a key, so I can contribute to the projects, I would appreciate it, hugs from Matheus Tatangelo!